### PR TITLE
Clarify this is a fork in the main help text

### DIFF
--- a/main.c
+++ b/main.c
@@ -30,7 +30,7 @@
 #include "utils.h"
 
 #ifndef PACKAGE_VERSION
-#define PACKAGE_VERSION "0.7.18-r1243-2"
+#define PACKAGE_VERSION "0.7.18-r1243-1"
 #endif
 
 int bwa_fa2pac(int argc, char *argv[]);

--- a/main.c
+++ b/main.c
@@ -30,7 +30,7 @@
 #include "utils.h"
 
 #ifndef PACKAGE_VERSION
-#define PACKAGE_VERSION "0.7.18-r1243-dirty"
+#define PACKAGE_VERSION "0.7.18-r1243-2"
 #endif
 
 int bwa_fa2pac(int argc, char *argv[]);
@@ -57,14 +57,16 @@ static int usage()
 {
 	fprintf(stderr, "\n");
 	fprintf(stderr, "Program: bwa (alignment via Burrows-Wheeler transformation)\n");
+	fprintf(stderr, "Fork:    This fork of bwa supports interactive `bwa aln`\n");
 	fprintf(stderr, "Version: %s\n", PACKAGE_VERSION);
-	fprintf(stderr, "Contact: Heng Li <hli@ds.dfci.harvard.edu>\n\n");
+	fprintf(stderr, "Contact: Fulcrum Genomics LLC <contact@fulcrumgenomics.com>\n\n");
 	fprintf(stderr, "Usage:   bwa <command> [options]\n\n");
+	fprintf(stderr, "NOTE:    For Bioconda installs replace `bwa` with `bwa-aln-interactive`\n\n");
 	fprintf(stderr, "Command: index         index sequences in the FASTA format\n");
 	fprintf(stderr, "         mem           BWA-MEM algorithm\n");
 	fprintf(stderr, "         fastmap       identify super-maximal exact matches\n");
 	fprintf(stderr, "         pemerge       merge overlapping paired ends (EXPERIMENTAL)\n");
-	fprintf(stderr, "         aln           gapped/ungapped alignment\n");
+	fprintf(stderr, "         aln           gapped/ungapped alignment (interactive)\n");
 	fprintf(stderr, "         samse         generate alignment (single ended)\n");
 	fprintf(stderr, "         sampe         generate alignment (paired ended)\n");
 	fprintf(stderr, "         bwasw         BWA-SW for long queries (DEPRECATED)\n");


### PR DESCRIPTION
Because our previous release ([`BWA-0.7.18-r1243`](https://github.com/fulcrumgenomics/bwa-aln-interactive/releases/tag/v0.7.18)) is broken  here and on bioconda, I intend to add a "patch"/"build" suffix of `-1` which we can further increment as we update this tool.

The bioconda distributed executable is named `bwa-aln-interactive` so I have added a notice to the main help text to notify users of that UI change. I also want the main program text to differ from `bwa` so it is easier for users to tell them apart.

Rendered help text:

```console
❯ ./bwa
Program: bwa (alignment via Burrows-Wheeler transformation)
Fork:    This fork of bwa supports interactive `bwa aln`
Version: 0.7.18-r1243-1
Contact: Fulcrum Genomics LLC <contact@fulcrumgenomics.com>

Usage:   bwa <command> [options]

NOTE:    For Bioconda installs replace `bwa` with `bwa-aln-interactive`

Command: index         index sequences in the FASTA format
         mem           BWA-MEM algorithm
         fastmap       identify super-maximal exact matches
         pemerge       merge overlapping paired ends (EXPERIMENTAL)
         aln           gapped/ungapped alignment (interactive)
         samse         generate alignment (single ended)
         sampe         generate alignment (paired ended)
         bwasw         BWA-SW for long queries (DEPRECATED)

         shm           manage indices in shared memory
         fa2pac        convert FASTA to PAC format
         pac2bwt       generate BWT from PAC
         pac2bwtgen    alternative algorithm for generating BWT
         bwtupdate     update .bwt to the new format
         bwt2sa        generate SA from BWT and Occ

Note: To use BWA, you need to first index the genome with `bwa index'.
      There are three alignment algorithms in BWA: `mem', `bwasw', and
      `aln/samse/sampe'. If you are not sure which to use, try `bwa mem'
      first. Please `man ./bwa.1' for the manual.
```


 